### PR TITLE
Related Products item in :admin_product_tab with Spree 0.50.2

### DIFF
--- a/app/views/admin/products/_related_products.html.erb
+++ b/app/views/admin/products/_related_products.html.erb
@@ -1,3 +1,3 @@
-<li<%= ' class="active"' if current == "Related Products" %>>
+<li<%= ' class=active' if current == "Related Products" %>>
   <%= link_to t("related_products"), related_admin_product_url(@product) %>
 </li>


### PR DESCRIPTION
Hi,

Noticed when the Related Products item in the :admin_product_tab is selected, the big green background arrow image (active) isn't being displayed.

Seems the reason is the HTML for the `<li>` is `<li class=""active"">`.

Ash.
