### PR TITLE
Fix wrong js/css links in product template override

### DIFF
--- a/app/views/admin/products/related.html.erb
+++ b/app/views/admin/products/related.html.erb
@@ -43,8 +43,8 @@
 
   <%= content_for :head do %>
     <%= javascript_tag "var expand_variants = false;" %>
-    <%= javascript_include_tag '/admin/javascripts/orders/edit.js' %>
-    <%= stylesheet_link_tag '/admin/stylesheets/edit_orders.css' %>
+    <%= javascript_include_tag '/javascripts/admin/orders/edit.js' %>
+    <%= stylesheet_link_tag '/stylesheets/admin/edit_orders.css' %>
 
     <script type="text/javascript">
       $("#add_related_product").live("click", function(){


### PR DESCRIPTION
Was "/admin/javascripts,stylesheets"
Should be "/javascripts,stylesheets/admin"
