### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Possible uses
 
 * Warranty & Support Products
 
-
-
 Relation Types
 --------------
 When you create a RelationType you can access that set of related products by referencing the relation_type name, see below for an example:
@@ -38,8 +36,18 @@ You can access all related products regardless of RelationType by:
         product.relations
          => []
 
-
 Discounts
 ---------
 If you install the spree-automatic-coupons extension you can also specify a discount amount to be applied if a customer purchases both products. Note: In order for the coupon to be automatically applied, you must create a coupon of type: __RelatedProductDiscount__ and leave the __code__ value empty (blank codes are required for coupons to be automatically applied).
 
+Installation
+------------
+
+Add to `Gemfile`:
+
+    gem 'spree_related_products', :git => 'git://github.com/spree/spree_related_products.git'
+
+Run:
+
+    $ bundle
+    $ bundle exec rails g spree_related_products:install


### PR DESCRIPTION
Points out that you need to run the generator so you don't forget your migrations.  Also fixes #5
