### PR TITLE
fixes an error when related product is not available

### DIFF
--- a/app/models/product_decorator.rb
+++ b/app/models/product_decorator.rb
@@ -14,7 +14,9 @@ Product.class_eval do
     if relation_type.nil?
       super
     else
-      relations.find_all_by_relation_type_id(relation_type.id).map(&:related_to).select {|product| product.deleted_at.nil? && product.available_on <= Time.now()}
+      relations.find_all_by_relation_type_id(relation_type.id).map(&:related_to).select do |product| 
+        product.deleted_at.nil? && !product.available_on.nil? && product.available_on <= Time.now()
+      end
     end
 
   end


### PR DESCRIPTION
inside que select block products are filtered by deleted_at and available_on, but if available_on is nil then an exception raises. this patch fixes the condition and tests first if available on ir not nil.
