### PR TITLE
Fixes a crash in Product#method_missing when the spree_relation_types missing (in master)

### DIFF
--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -120,4 +120,16 @@ describe Spree::Product do
       end
     end
   end
+
+  context "instance when relation_types table is missing" do
+    it 'method missing should not throw ActiveRecord::StatementInvalid when the spree_relation_types table is missing' do
+      Spree::Product.connection.rename_table('spree_relation_types', 'missing_relation_types')
+      begin
+        product = Spree::Product.new
+        expect { product.foo }.to raise_error(NameError)
+      ensure
+        Spree::Product.connection.rename_table('missing_relation_types', 'spree_relation_types')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi, 

When the spree_relation_types table is missing, and Product#method_missing is called, then an ActiveRecord::StatementInvalid exception is thrown. Since this can happen during a migration from a different extension that might run before the table is created, I made Product#method_missing more durable in that instance. 

I fixed this in the 0-70-stable branch first, but there was not a good way to test it over there. So, I wrote a test for the change in the master branch, and then ported the fix over.

Thanks,
-Scott
