### PR TITLE
Fixes a crash in Product#method_missing when the spree_relation_types missing (in 0-70-stable)

### DIFF
--- a/app/models/product_decorator.rb
+++ b/app/models/product_decorator.rb
@@ -6,7 +6,15 @@ Product.class_eval do
   end
 
   def method_missing(method, *args)
-    relation_type =  self.class.relation_types.detect { |rt| rt.name.downcase.gsub(" ", "_").pluralize == method.to_s.downcase }
+    relation_type = nil
+    begin
+      relation_type =  self.class.relation_types.detect { |rt| rt.name.downcase.gsub(" ", "_").pluralize == method.to_s.downcase }
+    rescue ActiveRecord::StatementInvalid => error
+      # This exception is throw if the relation_types table does not exist. 
+      # And this method is getting invoked during the execution of a migration 
+      # from another extension when both are used in a project.
+      relation_type = nil
+    end
 
     # Fix for Ruby 1.9
     raise NoMethodError if method == :to_ary


### PR DESCRIPTION
Hi, 

When the spree_relation_types table is missing, and Product#method_missing is called, then an ActiveRecord::StatementInvalid exception is thrown. Since this can happen during a migration from a different extension that might run before the table is created, I made Product#method_missing more durable in that instance. 

There are no tests in this version, because it was too much of a pain to add them. To see tests for this, check the version of the fix for the master branch. (pull request #19)

Thanks,
-Scott
