### PR TITLE
Fix admin related products autocomplete

### DIFF
--- a/app/views/admin/products/related.html.erb
+++ b/app/views/admin/products/related.html.erb
@@ -43,8 +43,8 @@
 
   <%= content_for :head do %>
     <%= javascript_tag "var expand_variants = false;" %>
-    <%= javascript_include_tag '/admin/javascripts/orders/edit.js' %>
-    <%= stylesheet_link_tag '/admin/stylesheets/edit_orders.css' %>
+    <%= javascript_include_tag 'admin/orders/edit' %>
+    <%= stylesheet_link_tag 'admin/autocomplete' %>
 
     <script type="text/javascript">
       $("#add_related_product").live("click", function(){


### PR DESCRIPTION
The autocomplete for selecting your related product was broken due to improper asset paths. 
