### PR TITLE
Migration to port relations between products to Spree 1.0

### DIFF
--- a/db/migrate/20120623014337_update_relations.rb
+++ b/db/migrate/20120623014337_update_relations.rb
@@ -1,0 +1,11 @@
+class UpdateRelations < ActiveRecord::Migration
+  def up
+    Spree::Relation.where(:relatable_type => 'Product').update_all(:relatable_type => 'Spree::Product')
+    Spree::Relation.where(:related_to_type => 'Product').update_all(:related_to_type => 'Spree::Product')
+  end
+
+  def down
+     Spree::Relation.where(:relatable_type => 'Spree::Product').update_all(:relatable_type => 'Product')
+    Spree::Relation.where(:related_to_type => 'Spree::Product').update_all(:related_to_type => 'Product')
+  end
+end


### PR DESCRIPTION
This expands on 83419168301cd432b56557941f11086045d0b627 but allows the actual relations to update to the namespaced site.

Should also be applied to the 1-0 branch.
