### PR TITLE
Add instructions to delete relations

### DIFF
--- a/app/models/spree/relation_type.rb
+++ b/app/models/spree/relation_type.rb
@@ -1,5 +1,5 @@
 class Spree::RelationType < ActiveRecord::Base
-  has_many :relations
+  has_many :relations, :dependent => :destroy
   
   attr_accessible :name, :applies_to, :description
 end


### PR DESCRIPTION
If the Relation Type is destroyed, makes sense do delete the relations,
otherwise it will crash when accessing the product "related products" link
