### PR TITLE
fixes markup on 'new relation type' button

### DIFF
--- a/app/views/spree/admin/relation_types/index.html.erb
+++ b/app/views/spree/admin/relation_types/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <div class='toolbar'>
-  <ul class='actions'>
+  <ul class='actions header-action-links inline-menu'>
     <li>
       <%= button_link_to t("new_relation_type"), new_object_url, :icon => 'add'  %>
     </li>


### PR DESCRIPTION
There is a bullet appearing to the left of the new relation type button.  This commit uses the same css classes as in the 'new product' button in spree core.
