### PR TITLE
Feature optimize routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,9 @@
-Spree::Core::Engine.routes.append do
-
+Spree::Core::Engine.routes.draw do
   namespace :admin do
-
     resources :relation_types
-    resources :products do
+    resources :products, only: [] do
       get :related, :on => :member
       resources :relations
     end
-
   end
-
 end


### PR DESCRIPTION
Don't use append, it ends up at the end (three times). By using the `only` option we avoid overwriting the search, as mentions in issue #58
