### PR TITLE
Defining :original for add_configuration_line

### DIFF
--- a/app/overrides/admin_decorator.rb
+++ b/app/overrides/admin_decorator.rb
@@ -8,4 +8,5 @@ Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :name => "add_configuration_line",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]",
                      :text => "<%= configurations_sidebar_menu_item(I18n.t('manage_relation_types'), admin_relation_types_url) %>",
-                     :disabled => false)
+                     :disabled => false,
+                     :original => "db886cb54ef1ca8a8284ab170ec7e19788d28259")


### PR DESCRIPTION
Responding to warning

[1;32mDeface:[0m 4 overrides found for 'spree/admin/shared/_configuration_menu'
[1;32mDeface:[0m 'add_configuration_line' matched 1 times with '[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]'
[1;32mDeface: [WARNING][0m No :original defined for 'add_configuration_line', you should change its definition to include:
 :original => 'db886cb54ef1ca8a8284ab170ec7e19788d28259'
