### PR TITLE
Error when deleting relation

### DIFF
--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -35,7 +35,6 @@ module Spree
         @relation = Relation.find(params[:id])
         @relation.destroy
 
-        # respond_with(@relation)
         redirect_to :back
       end
 


### PR DESCRIPTION
This fixes a missing route error when trying to delete a relation.

This uses part of the changes in #68 - those changes were never merged, but I ran into this issue and this was the minimal fix that corrected it.
