### PR TITLE
Specs and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Gemfile.lock
 pkg
 spec/dummy
 *~
+tmp
+.localeapp
+coverage

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
 --color
---format=nested
---backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,14 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-bundler_args: --without development production --quiet
 before_script:
-  - "bundle exec rake test_app"
-script: "DISPLAY=:99.0 bundle exec rake spec"
+  - sh -e /etc/init.d/xvfb start
+  - export DISPLAY=:99.0
+  - bundle exec rake test_app
+script:
+  - bundle exec rspec spec
 notifications:
   email:
     - ryan@spreecommerce.com
     - jdyer@spreecommerce.com
     - brian@spreecommerce.com
-branches:
-  only:
-    - master
-    - 1-0-stable
-    - 1-1-stable
-    - 1-2-stable
-    - 1-3-stable

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,10 @@
+guard "rspec", cmd: "bundle exec rspec", all_on_start: true, all_after_pass: true do
+  watch("spec/spec_helper.rb")                       { "spec" }
+  watch("config/routes.rb")                          { "spec/controllers" }
+  watch(%r{^spec/(.+)_spec\.rb$})                    { |m| "spec/#{m[1]}_spec.rb"}
+  watch(%r{^app/(.+)_decorator\.rb$})                { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.+)\.rb$})                          { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb)$})                       { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})                          { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$}) { |m| "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb" }
+end

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+Copyright (c) 2014 Brian Quinn and contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name Spree nor the names of its contributors may be used to
+      endorse or promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Related Products
 ================
 
-[![Build
-Status](https://secure.travis-ci.org/spree/spree_related_products.png)](http://travis-ci.org/spree/spree_related_products)
+[![Build Status](https://api.travis-ci.org/spree/spree_related_products.png?branch=master)](https://travis-ci.org/spree/spree_related_products)
 
 This extension provides a generic way for you to define different types of relationships between your products, by defining a RelationType for each type of relationship you'd like to maintain.
 
@@ -12,66 +11,90 @@ Possible uses
 -------------
 
 * Accessories
-
 * Cross Sells
-
 * Up Sells
-
 * Compatible Products
-
 * Replacement Products
-
 * Warranty & Support Products
 
 Relation Types
 --------------
-When you create a RelationType you can access that set of related products by referencing the relation_type name, see below for an example:
 
-        rt = Spree::RelationType.create(:name => "Accessories", :applies_to => "Spree::Product")
-         => #<Spree::RelationType id: 4, name: "Accessories" ...>
-        product = Spree::Product.last
-         => #<Spree::Product id: 1060500592 ...>
-        product.accessories
-         => []
+When you create a RelationType you can access that set of related products by referencing the relation_type name, see below for an example:
+```ruby
+rt = Spree::RelationType.create(name: 'Accessories', applies_to: 'Spree::Product')
+ => #<Spree::RelationType id: 4, name: "Accessories" ...>
+product = Spree::Product.last
+ => #<Spree::Product id: 1060500592 ...>
+product.accessories
+ => []
+```
 
 Since respond_to? will not work in this case, you can test whether a relation_type method exists with has_related_products?(method):
 
-	product.has_related_products?("accessories")
-	 => true
+    product.has_related_products?('accessories')
+     => true
 
-	if product.has_related_products?("accessories")
-	  # Display an accessories box
-	end
+    if product.has_related_products?('accessories')
+      # Display an accessories box
+    end
 
 You can access all related products regardless of RelationType by:
+```ruby
+product.relations
+ => []
+```
 
-        product.relations
-         => []
-
-Discounts
+**Discounts**
 You can optionally specify a discount amount to be applied if a customer purchases both products.
 
 Note: In order for the coupon to be automatically applied, you must create a promotion leaving the __code__ value empty, and adding an Action of type : __RelatedProductDiscount__  (blank codes are required for coupons to be automatically applied).
 
-Installation
-------------
+## Installation
 
 Add to `Gemfile`:
-
-    gem 'spree_related_products', :git => 'git://github.com/spree/spree_related_products.git'
+```ruby
+gem 'spree_related_products', github: 'spree/spree_related_products', branch: 'master'
+```
 
 Run:
+```sh
+$ bundle install
+$ rails g spree_related_products:install
+```
 
-    $ bundle
-    $ bundle exec rails g spree_related_products:install
+Contributing
+------------
 
-Development
------------
+In the spirit of [free software][1], **everyone** is encouraged to help improve this project.
 
-    * Fork the repo
-    * clone your repo
-    * Run `bundle`
-    * Run `bundle exec rake test_app` to create the test application in `spec/test_app`.
-    * Make your changes.
-    * Ensure specs pass by running `bundle exec rake`
-    * Submit your pull request
+Here are some ways *you* can contribute:
+
+* by using prerelease versions
+* by reporting [bugs][2]
+* by suggesting new features
+* by writing translations
+* by writing or editing documentation
+* by writing specifications
+* by writing code (*no patch is too small*: fix typos, add comments, clean up inconsistent whitespace)
+* by refactoring code
+* by resolving [issues][2]
+* by reviewing patches
+
+Starting point:
+
+* Fork the repo
+* Clone your repo
+* Run `bundle install`
+* Run `bundle exec rake test_app` to create the test application in `spec/test_app`
+* Make your changes
+* Ensure specs pass by running `bundle exec rspec spec`
+* Submit your pull request
+
+Copyright (c) 2014 [Brian Quinn][5] and [contributors][6], released under the [New BSD License][3]
+
+[1]: http://www.fsf.org/licensing/essays/free-sw.html
+[2]: https://github.com/spree/spree_related_products/issues
+[3]: https://github.com/spree/spree_related_products/blob/master/LICENSE.md
+[5]: https://github.com/BDQ
+[6]: https://github.com/spree/spree_related_products/graphs/contributors

--- a/Versionfile
+++ b/Versionfile
@@ -1,4 +1,6 @@
-"2.0.x"  => { :branch => "master" }
+"2.2.x"  => { :branch => "master" }
+"2.1.x"  => { :branch => "2-1-stable" }
+"2.0.x"  => { :branch => "2-0-stable" }
 "1.3.x"  => { :branch => "1-3-stable" }
 "1.2.x"  => { :branch => "1-2-stable" }
 "1.1.x"  => { :branch => "1-1-stable" }

--- a/app/assets/javascripts/spree/backend/spree_related_products.js
+++ b/app/assets/javascripts/spree/backend/spree_related_products.js
@@ -1,0 +1,1 @@
+//= require spree/backend

--- a/app/assets/stylesheets/spree/backend/spree_related_products.css
+++ b/app/assets/stylesheets/spree/backend/spree_related_products.css
@@ -1,0 +1,3 @@
+/*
+ *= require spree/backend
+*/

--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -25,7 +25,7 @@ module Spree
         params[:positions].each do |id, index|
           model_class.where(:id => id).update_all(:position => index)
         end
-    
+
         respond_to do |format|
           format.js  { render :text => 'Ok' }
         end
@@ -45,7 +45,7 @@ module Spree
       end
 
       def load_data
-        @product = Spree::Product.find_by_permalink(params[:product_id])
+        @product = Spree::Product.find_by_slug(params[:product_id])
       end
 
       def model_class

--- a/app/models/spree/calculator/related_product_discount.rb
+++ b/app/models/spree/calculator/related_product_discount.rb
@@ -16,7 +16,7 @@ module Spree
 
       return unless eligible?(order)
       total = order.line_items.inject(0) do |total, line_item|
-        relations =  Spree::Relation.find(:all, :conditions => ["discount_amount <> 0.0 AND relatable_type = ? AND relatable_id = ?", "Spree::Product", line_item.variant.product.id])
+        relations = Spree::Relation.where(["discount_amount <> 0.0 AND relatable_type = ? AND relatable_id = ?", "Spree::Product", line_item.variant.product.id])
         discount_applies_to = relations.map {|rel| rel.related_to.master }
 
         order.line_items.each do |li|

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -22,7 +22,10 @@ Spree::Product.class_eval do
   # This could also feasibly be overridden to sort the result in a
   # particular order, or restrict the number of items returned.
   def self.relation_filter
-    where('spree_products.deleted_at' => nil).where('spree_products.available_on IS NOT NULL').where('spree_products.available_on <= ?', Time.now)
+    where('spree_products.deleted_at' => nil).
+    where('spree_products.available_on IS NOT NULL').
+    where('spree_products.available_on <= ?', Time.now).
+    references(self)
   end
 
   # Decides if there is a relevant Spree::RelationType related to this class
@@ -72,7 +75,7 @@ Spree::Product.class_eval do
     result = self.class.where(:id => related_ids)
 
     # Merge in the relation_filter if it's available
-    result = result.merge(self.class.relation_filter.all) if relation_filter
+    result = result.merge(self.class.relation_filter.references(self).to_a) if relation_filter
 
     # make sure results are in same order as related_ids array  (position order)
     result = related_ids.collect {|id| result.detect {|x| x.id == id} } if result.present?

--- a/app/models/spree/relation_type.rb
+++ b/app/models/spree/relation_type.rb
@@ -1,3 +1,6 @@
 class Spree::RelationType < ActiveRecord::Base
   has_many :relations, :dependent => :destroy
+
+  validates :name, :applies_to, presence: true
+  validates :name, uniqueness: { case_sensitive: false }
 end

--- a/app/overrides/admin_decorator.rb
+++ b/app/overrides/admin_decorator.rb
@@ -7,5 +7,5 @@ Deface::Override.new(:virtual_path => "spree/admin/shared/_product_tabs",
 Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :name => "add_configuration_line",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]",
-                     :text => "<%= configurations_sidebar_menu_item(Spree.t('manage_relation_types'), admin_relation_types_url) %>",
+                     :text => "<%= configurations_sidebar_menu_item(Spree.t('manage_relation_types'), admin_relation_types_path) %>",
                      :disabled => false)

--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -21,8 +21,8 @@
           <span class="handle"></span>
         </td>
         <td><%= link_to relation.related_to.name, relation.related_to %></td>
-        <td><%= form_for(relation, url:admin_product_relation_path(relation.relatable, relation)) do |f| %>
-           <%= f.text_field :discount_amount, :style => "width:100px;" %> &nbsp; <%= f.submit Spree.t(:update) %> <% end %></td>
+        <td class="align-center"><%= form_for(relation, url:admin_product_relation_path(relation.relatable, relation)) do |f| %>
+           <%= f.text_field :discount_amount, :style => "text-align:center;width:100px;" %> &nbsp; <%= f.submit Spree.t(:update) %> <% end %></td>
         <td class="align-center"><%= relation.relation_type.name %></td>
         <td class="actions">
           <%= link_to_delete relation, {:url => admin_product_relation_url(relation.relatable, relation), :no_text => true} %>

--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -22,7 +22,7 @@
       </div>
       <div id='related_product_discount' class='columns three'>
         <%= label_tag :add_discount, Spree.t("discount_amount") %>
-        <%= text_field_tag :add_discount, 0.0, :style => 'margin: 0pt; padding: 4px; font-size: 1.5em; width: 98%;'  %>
+        <%= text_field_tag :add_discount, 0.0, :style => 'text-align:center;margin:0;padding:4px;font-size:1.5em;width:98%;' %>
       </div>
       <div id='related_product_add' class='columns one'>
         <label style='visibility: hidden;'>&nbsp;</label>
@@ -46,8 +46,8 @@
         update_target = jQuery(this).attr("data-update");
 
         jQuery.ajax({
-          dataType: 'script', 
-          url: this.href, 
+          dataType: 'script',
+          url: this.href,
           type: "POST",
           data: {
             "relation[related_to_type]" : "Product",

--- a/app/views/spree/admin/relation_types/_form.html.erb
+++ b/app/views/spree/admin/relation_types/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="six columns">
     <div data-hook="name" class="field">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t("name") %><br />
+        <%= f.label :name, Spree.t("name") %> <span class="required">*</span><br />
         <%= f.text_field :name, :class => 'fullwidth title' %>
         <%= error_message_on :relation_type, :name %>
       <% end %>
@@ -11,9 +11,9 @@
   <div class="four columns">
     <div data-hook="applies_to" class="field">
       <%= f.field_container :applies_to do %>
-        <%= f.label :applies_to, Spree.t("applies_to") %><br />
+        <%= f.label :applies_to, Spree.t("applies_to") %> <span class="required">*</span><br />
         <%= f.text_field :applies_to, :value => f.object.nil? ? "Spree::Product" : f.object.applies_to, :class => 'fullwidth title' %>
-        <%= error_message_on :relation_type, :applies_to%>
+        <%= error_message_on :relation_type, :applies_to %>
   <% end %>
     </div>
   </div>

--- a/app/views/spree/admin/relation_types/index.html.erb
+++ b/app/views/spree/admin/relation_types/index.html.erb
@@ -1,18 +1,15 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:relation_types) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <ul class="actions inline-menu">
-    <li>
-      <%= button_link_to Spree.t(:new_relation_type), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_relation_type' }  %>
-    </li>
-  </ul>
+  <li><%= button_link_to Spree.t(:new_relation_type), new_object_url, { :icon => 'icon-plus', :id => 'admin_new_relation_type' } %></li>
 <% end %>
 
-<table class="index" id='listing_relation_types' data-hook>
+<% if @relation_types.any? %>
+<table class="index responsive" id="listing_relation_types" data-hook>
   <colgroup>
     <col style="width: 20%" />
     <col style="width: 20%" />
@@ -24,7 +21,7 @@
       <th><%= Spree.t(:name) %></th>
       <th><%= Spree.t(:applies_to) %></th>
       <th><%= Spree.t(:description) %></th>
-      <th class="actions"></th>
+      <th class="actions" data-hook="admin_pages_index_header_actions"></th>
     </tr>
   </thead>
   <tbody>
@@ -33,7 +30,7 @@
         <td class="align-center"><%= relation_type.name %></td>
         <td class="align-center"><%= relation_type.applies_to %></td>
         <td class="align-center"><%= relation_type.description %></td>
-        <td class="actions">
+        <td class="actions" data-hook="admin_relation_types_index_row_actions">
           <%= link_to_edit relation_type, :no_text => true %>
           <%= link_to_delete relation_type, :no_text => true %>
         </td>
@@ -41,4 +38,9 @@
     <% end %>
   </tbody>
 </table>
-
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree.t(:relation_types)) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_relation_type_path %>!
+  </div>
+<% end %>

--- a/app/views/spree/admin/relations/create.js.erb
+++ b/app/views/spree/admin/relations/create.js.erb
@@ -2,3 +2,4 @@ $("#products-table-wrapper").html('<%= escape_javascript(render "spree/admin/pro
 $('#add_product_name').val('');
 $('#add_variant_id').val('');
 $('#add_quantity').val(1);
+$('.with-tip').powerTip();

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,6 @@
 cs:
   spree:
+    back_to_relation_types_list: Zpět na vztahu seznamu typů
     new_relation_type: Nový typ relace
     related_product_discount: Sleva pro související zboží
     relation_types: Typy vztahů

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,6 @@
 de:
   spree:
+    back_to_relation_types_list: Zurück zu Beziehungstypen Liste
     new_relation_type: Neuer Verwandschaftstyp
     related_product_discount: Skonto für verwandte Produkte
     relation_types: Verwandschaftstypen
@@ -7,5 +8,6 @@ de:
     editing_relation_type: Verwandschaftstyp bearbeiten
     related_products: Verwandte Produkte
     add_related_product: Verwandtes Produkt hinzufügen
+    name_or_sku: Name oder Artikelnummer
     manage_relation_types: Verwandschaftstypen konfigurieren
     no_relation_types: "Sie müssen Verwandschaftstypen konfigurieren, bevor Sie diese Funktion nutzen können."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,5 +9,5 @@ en:
     related_products: Related Products
     add_related_product: Add Related Product
     name_or_sku: Name or SKU
-    manage_relation_types: Manage relation types
+    manage_relation_types: Manage Relation Types
     no_relation_types: You need to configure Relation Types before you can use this feature.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,6 @@
 es:
   spree:
+    back_to_relation_types_list: Volver a la lista de tipos de relación
     new_relation_type: Nuevo tipo de relación
     related_product_discount: Descuento al producto relacionado
     relation_types: Tipos de relación

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,6 @@
 nl:
   spree:
+    back_to_relation_types_list: Terug naar verhouding lijsttypen
     new_relation_type: Nieuw relatie type
     related_product_discount: Korting gerelateerd product
     relation_types: Relatie types

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,6 @@
 pt-BR:
   spree:
+    back_to_relation_types_list: Voltar para lista de tipos de relação
     new_relation_type: Novo tipo de relacionamento
     related_product_discount: Desconto de produto relacionado
     relation_types: Tipos de relacionamento

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,5 +1,6 @@
 ru:
   spree:
+    back_to_relation_types_list: Вернуться к соотношению списке типов
     new_relation_type: Новый Тип Отношений
     related_product_discount: Скидка На Относящийся Товар
     relation_types: Типы Отношений

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,0 +1,14 @@
+sv:
+  spree:
+    back_to_relation_types_list: Tillbaks till relationstyplistan
+    new_relation_type: Ny typ av relation
+    related_product_discount: Relaterad produkt rabatt
+    relation_types: Relationstyper
+    applies_to: Gäller
+    editing_relation_type: Redigera relationstyp
+    related_products: Relaterade produkter
+    add_related_product: Lägg till relaterad produkt
+    name_or_sku: Namn eller SKU
+    manage_relation_types: Hantera relationstyper
+    no_relation_types: Du måste konfigurera relationstyper innan du kan använda den här funktionen.
+    successfully_created_relation: Relationen har skapats.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.routes.draw do
+Spree::Core::Engine.add_routes do
   namespace :admin do
     resources :relation_types
     resources :products, only: [] do

--- a/lib/spree_related_products.rb
+++ b/lib/spree_related_products.rb
@@ -1,5 +1,6 @@
 require 'spree_backend'
 require 'spree_core'
+require 'coffee_script'
 
 module SpreeRelatedProducts
   class Engine < Rails::Engine

--- a/script/rails
+++ b/script/rails
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../spec/dummy/script/rails',  __FILE__)
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/spree_related_products/engine', __FILE__)
+
+require 'rails/all'
+require 'rails/engine/commands'

--- a/spec/controllers/spree/admin/products_controller_decorator_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_decorator_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Spree::Admin::ProductsController do
+  stub_authorization!
+
+  let(:user) { create(:user) }
+
+  before { controller.stub(spree_current_user: user) }
+  after  { Spree::Admin::ProductsController.clear_overrides! }
+
+  context 'related' do
+    it 'is not routable' do
+      spree_get :related
+      expect(response.status).to eq(200)
+    end
+
+    it 'respond to model_class as Spree::Relation' do
+      expect(controller.send(:model_class)).to eq(Spree::Product)
+    end
+  end
+end

--- a/spec/controllers/spree/admin/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/relations_controller_spec.rb
@@ -1,33 +1,78 @@
 require 'spec_helper'
 
 describe Spree::Admin::RelationsController do
-  
   stub_authorization!
-  include Spree::TestingSupport::ControllerRequests
 
-  it "should respond to model_class as Spree::Relation" do
-    controller.send(:model_class).should eql(Spree::Relation)
-  end
+  let(:user)     { create(:user) }
+  let!(:product) { create(:product) }
+  let!(:other1)  { create(:product) }
 
-  context "POST#update_positions" do
+  let!(:relation_type) { create(:relation_type) }
+  let!(:relation) { create(:relation, relatable: product, related_to: other1, relation_type: relation_type, position: 0) }
 
-    it "should return the correct position of the related products" do
-      
-      @product = FactoryGirl.create(:product)
+  before { controller.stub(spree_current_user: user) }
+  after  { Spree::Admin::ProductsController.clear_overrides! }
 
-      other1 = FactoryGirl.create(:product)
-      other2 = FactoryGirl.create(:product)
-
-      @relation_type = Spree::RelationType.create(:name => "Related Products", :applies_to => "Spree::Product")
-
-      @relation = Spree::Relation.create!(:relatable => @product, :related_to => other1, :relation_type => @relation_type, :position => 0 )
-      @relation2 = Spree::Relation.create!(:relatable => @product, :related_to => other2, :relation_type => @relation_type, :position => 1 )
-      
-      expect {
-        spree_post :update_positions, :id => @relation.id, :positions => { @relation.id => '1', @relation2.id => '0' }, :format => "js"
-        @relation.reload
-      }.to change(@relation, :position).from(0).to(1)
+  context 'model_class' do
+    it 'respond to model_class as Spree::Relation' do
+      expect(controller.send(:model_class)).to eq(Spree::Relation)
     end
   end
 
+  describe 'with JS' do
+    let(:valid_params) do
+      { format: :js,
+        product_id: product.id,
+        relation: { related_to_id: other1.id,
+                    relation_type: { name: relation_type.name,
+                                     applies_to: relation_type.applies_to } } }
+    end
+
+    context '#create' do
+      it 'is not routable' do
+        spree_post :create, valid_params
+        expect(response.status).to eq(200)
+      end
+
+      xit 'return success with valid params' do
+        pending 'fix hash params'
+        expect {
+          spree_post :create, valid_params
+        }.to change(Spree::Relation, :count).by(1)
+      end
+
+      it 'raise error with invalid params' do
+        expect {
+          spree_post :create, { format: :js }
+        }.to raise_error
+      end
+    end
+
+    context '#update' do
+      it 'redirect product/related url' do
+        spree_post :update, { id: 1, relation: { discount_amount: 2.0 } }
+        expect(response).to redirect_to(spree.admin_product_path(relation.relatable) + '/related')
+      end
+    end
+
+    context '#destory with' do
+      it 'record successfully' do
+        expect {
+          spree_delete :destroy, { id: 1, format: :js }
+        }.to change(Spree::Relation, :count).by(-1)
+      end
+    end
+
+    context '#update_positions' do
+      it 'return the correct position of the related products' do
+        other2    = create(:product)
+        relation2 = create(:relation, relatable: product, related_to: other2, relation_type: relation_type, position: 1)
+
+        expect {
+          spree_post :update_positions, { id: relation.id, positions: { relation.id => '1', relation2.id => '0' }, format: :js }
+          relation.reload
+        }.to change(relation, :position).from(0).to(1)
+      end
+    end
+  end
 end

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :relation, class: Spree::Relation do
+    association :relatable, factory: :product
+    association :related_to, factory: :product
+    relation_type 'Spree::Product'
+  end
+end

--- a/spec/factories/relation_type_factory.rb
+++ b/spec/factories/relation_type_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :relation_type, class: Spree::RelationType do
+    name       { generate(:random_string) }
+    applies_to 'Spree::Product'
+  end
+end

--- a/spec/features/spree/admin/product_relation_spec.rb
+++ b/spec/features/spree/admin/product_relation_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+feature 'Admin Product Relation', js: true do
+  stub_authorization!
+
+  given!(:product) { create(:product) }
+  given!(:other)   { create(:product) }
+
+  given!(:relation_type) { create(:relation_type, name: 'Gears') }
+
+  background do
+    visit spree.edit_admin_product_path(product)
+    click_link 'Related Products'
+  end
+
+  scenario 'create relation' do
+    pending 'unable to select2_search product/other name'
+
+    expect(page).to have_text 'Add Related Product'.upcase
+    expect(page).to have_text product.name
+
+    within('#add-line-item') do
+      select2_search other.name, from: 'Name or SKU'
+      select2_search relation_type.name, from: 'Type'
+      fill_in 'add_discount', with: '0.8'
+      click_link 'Add'
+    end
+
+    wait_for_ajax
+
+    within_row(1) do
+      expect(page).to have_field('relation_discount_amount', with: '0.8')
+      expect(column_text(2)).to eq other.name
+      expect(column_text(4)).to eq relation_type.name
+    end
+  end
+
+  context 'with relations' do
+    given!(:relation) do
+      create(:relation, relatable: product, related_to: other, relation_type: relation_type, discount_amount: 0.5)
+    end
+
+    background do
+      visit spree.edit_admin_product_path(product)
+      click_link 'Related Products'
+    end
+
+    scenario 'ensure on content' do
+      expect(page).to have_text 'Add Related Product'.upcase
+      expect(page).to have_text product.name
+      expect(page).to have_text other.name
+
+      within_row(1) do
+        expect(page).to have_field('relation_discount_amount', with: '0.5')
+        expect(column_text(2)).to eq other.name
+        expect(column_text(4)).to eq relation_type.name
+      end
+    end
+
+    scenario 'update discount' do
+      within_row(1) do
+        fill_in 'relation_discount_amount', with: '0.9'
+        click_on 'Update'
+      end
+      wait_for_ajax
+      within_row(1) do
+        expect(page).to have_field('relation_discount_amount', with: '0.9')
+      end
+    end
+
+    scenario 'delete' do
+      within_row(1) do
+        click_icon :trash
+      end
+      wait_for_ajax
+      expect(page).not_to have_text other.name
+    end
+  end
+end

--- a/spec/features/spree/admin/relation_types_spec.rb
+++ b/spec/features/spree/admin/relation_types_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+feature 'Admin Manage Relation Types', js: true do
+  stub_authorization!
+
+  background do
+    visit spree.admin_path
+    click_link 'Configuration'
+    click_link 'Manage Relation Types'
+  end
+
+  scenario 'when no relation types exists' do
+    expect(page).to have_text 'NO RELATION TYPES FOUND, ADD ONE!'
+  end
+
+  context '#create' do
+    scenario 'can create a new relation type' do
+      click_link 'New Relation Type'
+      expect(current_path).to eq spree.new_admin_relation_type_path
+
+      fill_in 'Name', with: 'Gears'
+      fill_in 'Applies To', with: 'Spree:Products'
+
+      click_button 'Create'
+
+      expect(page).to have_text 'successfully created!'
+      expect(current_path).to eq spree.admin_relation_types_path
+    end
+
+    scenario 'will show validation errors with blank name' do
+      click_link 'New Relation Type'
+      expect(current_path).to eq spree.new_admin_relation_type_path
+
+      fill_in 'Name', with: ''
+      click_button 'Create'
+
+      expect(page).to have_text 'Name can\'t be blank'
+    end
+
+    scenario 'will show validation errors with blank applies_to' do
+      click_link 'New Relation Type'
+      expect(current_path).to eq spree.new_admin_relation_type_path
+
+      fill_in 'Name', with: 'Gears'
+      fill_in 'Applies To', with: ''
+      click_button 'Create'
+
+      expect(page).to have_text 'Applies to can\'t be blank'
+    end
+  end
+
+  context 'with records' do
+    background do
+      %w(Gears Equipments).each do |name|
+        create(:relation_type, name: name)
+      end
+      visit spree.admin_relation_types_path
+    end
+
+    context '#show' do
+      scenario 'will display existing relation types' do
+        within_row(1) do
+          expect(column_text(1)).to eq 'Gears'
+          expect(column_text(2)).to eq 'Spree::Product'
+          expect(column_text(3)).to eq ''
+        end
+      end
+    end
+
+    context '#edit' do
+      background do
+        within_row(1) { click_icon :edit }
+        expect(current_path).to eq spree.edit_admin_relation_type_path(1)
+      end
+
+      scenario 'can update an existing relation type' do
+        fill_in 'Name', with: 'Gadgets'
+        click_button 'Update'
+        expect(page).to have_text 'successfully updated!'
+        expect(page).to have_text 'Gadgets'
+      end
+
+      scenario 'will show validation errors if there are any' do
+        fill_in 'Name', with: ''
+        click_button 'Update'
+        expect(page).to have_text 'Name can\'t be blank'
+      end
+    end
+
+    context '#delete' do
+      scenario 'they can be removed' do
+        within_row(1) do
+          expect(column_text(1)).to eq 'Gears'
+          click_icon :trash
+        end
+        page.driver.browser.switch_to.alert.accept unless Capybara.javascript_driver == :poltergeist
+        expect(page).to have_text 'successfully removed!'
+      end
+    end
+  end
+end

--- a/spec/models/spree/calculator/related_product_discount_spec.rb
+++ b/spec/models/spree/calculator/related_product_discount_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Spree::Calculator::RelatedProductDiscount do
+  let(:user) { create(:user) }
+  let(:related_product_discount) { Spree::Calculator::RelatedProductDiscount.new }
+
+  describe 'instance' do
+    context '.description' do
+      it 'output relation product discount' do
+        expect(related_product_discount.description).to eq Spree.t(:related_product_discount)
+      end
+    end
+  end
+
+  describe 'class' do
+    before do
+      @order    = stub_model(Spree::Order)
+      product   = stub_model(Spree::Product)
+      variant   = stub_model(Spree::Variant, product: product)
+      price     = stub_model(Spree::Price, variant: variant, amount: 5.00)
+      line_item = stub_model(Spree::LineItem, variant: variant, order: @order, quantity: 1, price: 4.99)
+
+      variant.stub(default_price: price)
+      @order.stub(line_items: [line_item])
+
+      related_product = create(:product)
+      relation_type   = create(:relation_type)
+
+      create(:relation, relatable: product, related_to: related_product, relation_type: relation_type, discount_amount: 1.0)
+    end
+
+    context '.compute' do
+      it 'return nil' do
+        expect(related_product_discount.compute([])).to be_nil
+      end
+
+      it 'return nil unless order is eligible' do
+        empty_order = stub_model(Spree::Order)
+        expect(related_product_discount.compute(empty_order)).to be_nil
+      end
+
+      it 'return total count of array' do
+        objects = Array.new { @order }
+        expect(related_product_discount.compute(objects)).to be_nil
+      end
+
+      it 'return total count' do
+        expect(related_product_discount.compute(@order)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Spree::Relation do
+  context 'relations' do
+    it { should belong_to(:relation_type) }
+    it { should belong_to(:relatable) }
+    it { should belong_to(:related_to) }
+  end
+
+  context 'validation' do
+    it { should validate_presence_of(:relation_type) }
+    it { should validate_presence_of(:relatable) }
+    it { should validate_presence_of(:related_to) }
+  end
+end

--- a/spec/models/spree/relation_type_spec.rb
+++ b/spec/models/spree/relation_type_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::RelationType do
+  context 'relations' do
+    it { should have_many(:relations).dependent(:destroy) }
+  end
+
+  context 'validation' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:applies_to) }
+    it { should validate_uniqueness_of(:name).case_insensitive }
+
+    it 'does not create duplicate names' do
+      create(:relation_type, name: 'Gears')
+      expect {
+        create(:relation_type, name: 'gears')
+      }.to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,44 @@
-# Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require 'simplecov'
+SimpleCov.start 'rails'
+
+ENV['RAILS_ENV'] = 'test'
+
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
+
 require 'rspec/rails'
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'capybara/poltergeist'
+require 'shoulda-matchers'
 require 'ffaker'
+require 'database_cleaner'
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
-# Requires factories defined in spree_core
 require 'spree/testing_support/factories'
-
-#Requires controller_requests defined in spree_core
 require 'spree/testing_support/controller_requests'
-
 require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/url_helpers'
+require 'spree/testing_support/capybara_ext'
+
+FactoryGirl.find_definitions
 
 RSpec.configure do |config|
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = true
+  config.include FactoryGirl::Syntax::Methods
+  config.include Spree::TestingSupport::ControllerRequests
+  config.include Spree::TestingSupport::UrlHelpers
+
+  config.mock_with :rspec
+  config.use_transactional_fixtures = false
+
+  config.before do
+    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
+
+  Capybara.javascript_driver = :poltergeist
 end

--- a/spree_related_products.gemspec
+++ b/spree_related_products.gemspec
@@ -3,15 +3,17 @@ Gem::Specification.new do |s|
   s.name        = 'spree_related_products'
   s.version     = '3.2'
   s.summary     = 'Allows multiple types of relationships between products to be defined'
-  s.description = 'Allows multiple types of relationships between products to be defined'
+  s.description = s.summary
   s.required_ruby_version = '>= 1.9.3'
 
   s.author            = 'Brian Quinn'
   s.email             = 'brian@railsdog.com'
   s.homepage          = 'http://spreecommerce.com'
   s.rubyforge_project = 'spree_related_products'
+  s.license           = %q{BSD-3}
 
-  s.files        = Dir['README.md', 'lib/**/*', 'app/**/*', 'config/*']
+  s.files        = `git ls-files`.split("\n")
+  s.test_files   = `git ls-files -- spec/*`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 
@@ -22,7 +24,15 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'factory_girl', '4.2'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails',  '~> 2.13.0'
-  s.add_development_dependency 'sqlite3'
-
+  s.add_development_dependency 'rspec-rails', '~> 2.14'
+  s.add_development_dependency 'sqlite3', '~> 1.3.8'
+  s.add_development_dependency 'capybara', '~> 2.2.1'
+  s.add_development_dependency 'poltergeist', '~> 1.5.0'
+  s.add_development_dependency 'shoulda-matchers', '~> 2.5'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'database_cleaner', '~> 1.2.0'
+  s.add_development_dependency 'coffee-rails', '~> 4.0.0'
+  s.add_development_dependency 'sass-rails', '~> 4.0.0'
+  s.add_development_dependency 'guard-rspec'
+  s.add_development_dependency 'pry-rails'
 end


### PR DESCRIPTION
- [x] Add more specs and better test support.
- [x] Updated Versionfile, README and add LICENSE file.
- [x] Let Travis run all branches.
- [x] Add missing locale keys + add Swedish locale.
- [x] Use `find_by_slug` not `find_by_permalink` for `Spree::Product`
- [x] Fixed additional deprecated finders (warnings only appeared with new specs).
- [x] `Spree::RelationType` `:name` and `:applies_to` should be required and `:name`
  should be unique.
- [x] Use new `.add_routes` instead of `.draw`
- [x] Minor layout tweaks and additional standard hooks.

:globe_with_meridians: Note: that locale key `name_or_sku` is duplicate but the English original version as seen on [localeapp](http://www.localeapp.com/projects/4605/translations?utf8=%E2%9C%93&in_locale=13851&search=name_or_sku) actual has description in it _"Name or SKU (enter at least first 4 characters of product name)"_ so the keys are necessary override until fixed.

@radar @peterberkenbosch @jdutil :smiley_cat: ping!
