### PR TITLE
Remove Inline Block From Variant Name Input

### DIFF
--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -15,7 +15,7 @@
         <div id="related_product_name" class="col-md-5">
           <div class="form-group">
             <%= label_tag :add_variant_name, Spree.t(:name_or_sku_short) %>
-            <%= hidden_field_tag :add_variant_name, '', class: 'variant_autocomplete' %>
+            <%= hidden_field_tag :add_variant_name, '', class: 'variant_autocomplete', style: "display: block !important;" %>
           </div>
         </div>
         <div id="related_product_type" class="col-md-4">


### PR DESCRIPTION
Formatting of the "Chose Variant Name" input field is broken on Spree 3, field is far too small and discovering products from the list if difficult. 