### PR TITLE
Fix pluralization of Spree::RelationType model in menu

### DIFF
--- a/app/overrides/add_product_relation_admin_sub_menu_tab.rb
+++ b/app/overrides/add_product_relation_admin_sub_menu_tab.rb
@@ -2,5 +2,5 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/sub_menu/_product',
   name: 'add_product_relation_admin_sub_menu_tab',
   insert_bottom: '[data-hook="admin_product_sub_tabs"]',
-  text: '<%= tab :relation_types, label: Spree::RelationType.model_name.human(count: :many) %>'
+  text: '<%= tab :relation_types, label: plural_resource_name(Spree::RelationType) %>'
 )


### PR DESCRIPTION
  See https://github.com/spree/spree/issues/5842

Adding French locale breaks the admin.