### PR TITLE
touch relatable when updated

### DIFF
--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -1,6 +1,6 @@
 class Spree::Relation < ActiveRecord::Base
   belongs_to :relation_type
-  belongs_to :relatable, polymorphic: true
+  belongs_to :relatable, polymorphic: true, touch: true
   belongs_to :related_to, polymorphic: true
 
   validates :relation_type, :relatable, :related_to, presence: true


### PR DESCRIPTION
Applies to 2-4, 3-0 as well.

This will invalidate anything using the relatable updated_at as a cache key.
