### PR TITLE
Fix destroy response

### DIFF
--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -35,7 +35,10 @@ module Spree
         @relation = Relation.find(params[:id])
         @relation.destroy
 
-        redirect_to :back
+        respond_with(@relation) do |format|
+          format.html { redirect_to related_admin_product_url(@product) }
+          format.js { render_js_for_destroy }
+        end
       end
 
       private


### PR DESCRIPTION
Because Spree 3.0 uses a remote link for the delete button, the page rendered as a result of the `redirect_to :back` response would be inserted in the notification flash.

This PR updates the response to use the same response as default Spree 3.0.