### PR TITLE
fix delete product relations bug

### DIFF
--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -33,9 +33,20 @@ module Spree
 
       def destroy
         @relation = Relation.find(params[:id])
-        @relation.destroy
+        if @relation.destroy
+          flash[:success] = flash_message_for(@relation, :successfully_removed)
 
-        redirect_to :back
+          respond_with(@relation) do |format|
+            format.html { redirect_to location_after_destroy }
+            format.js   { render :partial => "spree/admin/shared/destroy" }
+          end
+
+        else
+
+          respond_with(@relation) do |format|
+            format.html { redirect_to location_after_destroy }
+          end
+        end
       end
 
       private

--- a/spec/controllers/spree/admin/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/relations_controller_spec.rb
@@ -66,9 +66,8 @@ RSpec.describe Spree::Admin::RelationsController, type: :controller do
 
     context '#destroy' do
       it 'records successfully' do
-        skip 'strange bug with delete record'
         expect {
-          spree_delete :destroy, id: 1, format: :js
+          spree_delete :destroy, id: 1, product_id: product.id, format: :js
         }.to change(Spree::Relation, :count).by(-1)
       end
     end

--- a/spec/features/spree/admin/product_relation_spec.rb
+++ b/spec/features/spree/admin/product_relation_spec.rb
@@ -66,7 +66,6 @@ RSpec.feature 'Admin Product Relation', :js do
 
     context 'delete' do
       scenario 'can remove records' do
-        skip 'strange bug with delete record'
         within_row(1) do
           expect(column_text(2)).to eq other.name
           click_icon :delete


### PR DESCRIPTION
ajax delete request to action relation_controller/destroy,  it redirect back when process successfully. 
browser get redirect response and request by ajax again, it cause that render relation list on top of original relations.