### PR TITLE
Set spree_backend to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_related_products.gemspec
+++ b/spree_related_products.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = false
 
-  s.add_runtime_dependency 'spree_backend', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'factory_girl', '4.4'
   s.add_development_dependency 'ffaker'


### PR DESCRIPTION
This PR changes the version of `spree_backend` in gemspec to point at `>= 3.1.0` and `< 4.0`.