### PR TITLE
Fix scoping issue in admin products_controller

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -1,10 +1,6 @@
-module Spree
-  module Admin
-    ProductsController.class_eval do
-      def related
-        load_resource
-        @relation_types = Spree::Product.relation_types
-      end
-    end
+Spree::Admin::ProductsController.class_eval do
+  def related
+    load_resource
+    @relation_types = Spree::Product.relation_types
   end
 end


### PR DESCRIPTION
The products controller decorators scoping was not taking effect. Hence,
the decorator was not being triggered.

We noticed this issue while visiting the admin products' related tab.
The @relation_types instance variable was unset.

Fixes issue #127
