### PR TITLE
Fix #137 - comparison of NilClass with BigDecimal failed

### DIFF
--- a/app/models/spree/calculator/related_product_discount.rb
+++ b/app/models/spree/calculator/related_product_discount.rb
@@ -12,22 +12,23 @@ module Spree
         order = object
       end
 
-      return unless eligible?(order)
-      total = order.line_items.inject(0) do |sum, line_item|
-        relations =  Spree::Relation.where(*discount_query(line_item))
-        discount_applies_to = relations.map {|rel| rel.related_to.master }
+      total = 0
+      if eligible?(order)
+        total = order.line_items.inject(0) do |sum, line_item|
+          relations =  Spree::Relation.where(*discount_query(line_item))
+          discount_applies_to = relations.map {|rel| rel.related_to.master.product }
+          order.line_items.each do |li|
+            next unless discount_applies_to.include? li.variant.product
+            discount = relations.detect { |rel| rel.related_to.master.product == li.variant.product }.discount_amount
+            sum +=  if li.quantity < line_item.quantity
+                      (discount * li.quantity)
+                    else
+                      (discount * line_item.quantity)
+                    end
+          end
 
-        order.line_items.each do |li|
-          next unless discount_applies_to.include? li.variant
-          discount = relations.detect { |rel| rel.related_to.master == li.variant }.discount_amount
-          sum +=  if li.quantity < line_item.quantity
-                    (discount * li.quantity)
-                  else
-                    (discount * line_item.quantity)
-                  end
+          sum
         end
-
-        sum
       end
 
       total

--- a/spec/models/spree/calculator/related_product_discount_spec.rb
+++ b/spec/models/spree/calculator/related_product_discount_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Spree::Calculator::RelatedProductDiscount, type: :model do
       expect(subject.compute([])).to be_nil
     end
 
-    it 'returns nil unless order is eligible' do
+    it 'returns 0 unless order is eligible' do
       empty_order = double('Spree::Order')
       allow(empty_order).to receive(:line_items).and_return([])
-      expect(subject.compute(empty_order)).to be_nil
+      expect(subject.compute(empty_order)).to be_zero
     end
 
-    context 'with order' do
+    context 'with order with single item' do
       before do
         @order    = double('Spree::Order')
         product   = build_stubbed(:product)
@@ -44,5 +44,43 @@ RSpec.describe Spree::Calculator::RelatedProductDiscount, type: :model do
         expect(subject.compute(@order)).to be_zero
       end
     end
+
+    context 'with order with related items' do
+      before do
+        @order    = double('Spree::Order')
+        product   = build_stubbed(:product)
+        variant   = double('Spree::Variant', product: product)
+        price     = double('Spree::Price', variant: variant, amount: 5.00)
+        @line_item = double('Spree::LineItem', variant: variant, order: @order, quantity: 1, price: 4.99)
+        @two_line_item = double('Spree::LineItem', variant: variant, order: @order, quantity: 2, price: 4.99)
+
+        allow(variant).to receive(:default_price).and_return(price)
+
+        related_product = create(:product)
+        related_variant   = double('Spree::Variant', product: related_product)
+        related_price     = double('Spree::Price', variant: related_variant, amount: 5.00)
+        @related_line_item = double('Spree::LineItem', variant: related_variant, order: @order, quantity: 1, price: 4.99)
+        @two_related_line_item = double('Spree::LineItem', variant: related_variant, order: @order, quantity: 2, price: 4.99)
+
+        allow(related_variant).to receive(:default_price).and_return(related_price)
+
+        related_product_2 = create(:product)
+        relation_type   = create(:relation_type)
+
+        create(:relation, relatable: product, related_to: related_product, relation_type: relation_type, discount_amount: 2.35)
+        create(:relation, relatable: product, related_to: related_product_2, relation_type: relation_type, discount_amount: 0.0)
+      end
+
+      it 'returns total discount for one related item' do
+        allow(@order).to receive(:line_items).and_return([@line_item, @related_line_item])
+        expect(subject.compute(@order)).to eq 2.35
+      end
+
+      it 'returns total discount for 2 related items' do
+        allow(@order).to receive(:line_items).and_return([@two_line_item, @two_related_line_item])
+        expect(subject.compute(@order)).to eq 2*2.35
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Here's an attempt at resolving the scenario in which there are no related products with no discount on the DB. The original implementation was returning nil but Spree 3.1 is using the return of `compare` and adding it to the total so the sum operation was failing. The fix proposed here is to return 0 when the promotion is not eligible, plus to compare for master products instead of specific variants.