### PR TITLE
Fix RelationType.model_name.human(count: :many) translation

### DIFF
--- a/app/views/spree/admin/relation_types/index.html.erb
+++ b/app/views/spree/admin/relation_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::RelationType.model_name.human(count: :many) %>
+  <%= Spree::RelationType.model_name.human(count: 2.1) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -38,7 +38,7 @@
   </table>
 <% else %>
   <div class="alert alert-warning no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: Spree::RelationType.model_name.human(count: :many)) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::RelationType.model_name.human(count: 2.1)) %>,
     <%= link_to Spree.t(:add_one), spree.new_admin_relation_type_path %>!
   </div>
 <% end %>


### PR DESCRIPTION
This fixes issue #131 and supplies an alternative for PR #135 which doesn't pass tests. 
I used `I18N_PLURAL_MANY_COUNT = 2.1` from gem `spree_backend` to replace `count: :many` which caused errors in Russian locale.