### PR TITLE
remove deprecated has_rdoc

### DIFF
--- a/spree_related_products.gemspec
+++ b/spree_related_products.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
   s.add_runtime_dependency 'spree_extension'
 


### PR DESCRIPTION
Warning message:

    NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.