### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_related_products.gemspec
+++ b/spree_related_products.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'spree_backend', '>= 3.1.0', '< 5.0'
   s.add_runtime_dependency 'spree_extension'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'pg', '~> 0.18'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here